### PR TITLE
Initialize rtaccess-app monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
+# rtaccess-app
 
+This repository contains a monorepo with three services:
+
+- **frontend** – React + Vite application written in TypeScript
+- **backend** – Express server written in TypeScript
+- **ai-service** – FastAPI service written in Python
+
+Each directory holds its own setup instructions and configuration files.

--- a/rtaccess-app/ai-service/README.md
+++ b/rtaccess-app/ai-service/README.md
@@ -1,0 +1,8 @@
+# AI Service
+
+This FastAPI application exposes machine learning capabilities. Start with `uvicorn main:app`.
+
+### `/generate-program`
+
+POST a JSON body `{ "description": "adults with autism" }` and receive a response
+with a generated program title and description. CORS is enabled for all origins.

--- a/rtaccess-app/ai-service/main.py
+++ b/rtaccess-app/ai-service/main.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import openai
+
+openai.api_key = "YOUR_OPENAI_KEY"
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ProgramRequest(BaseModel):
+    description: str
+
+class ProgramResponse(BaseModel):
+    title: str
+    description: str
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello from ai-service!"}
+
+
+@app.post("/generate-program", response_model=ProgramResponse)
+async def generate_program(req: ProgramRequest):
+    try:
+        # Simple prompt to generate a title and description
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a rehabilitation therapist assistant program generator.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Create a program idea for {req.description}",
+                },
+            ],
+        )
+        text = completion.choices[0].message.content
+        lines = text.split("\n", 1)
+        title = lines[0].strip()
+        description = lines[1].strip() if len(lines) > 1 else ""
+        return ProgramResponse(title=title, description=description)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/rtaccess-app/ai-service/requirements.txt
+++ b/rtaccess-app/ai-service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+openai

--- a/rtaccess-app/backend/README.md
+++ b/rtaccess-app/backend/README.md
@@ -1,0 +1,7 @@
+# Backend
+
+This Express server is written in TypeScript. Run `npm run dev` for development or `npm start` after building.
+
+API routes under `/api` are protected by Firebase authentication middleware. Send an `Authorization: Bearer <token>` header obtained from the frontend.
+
+Prisma is used for the PostgreSQL database schema. Run `npx prisma generate` after installing dependencies and set a `DATABASE_URL` in your environment.

--- a/rtaccess-app/backend/package.json
+++ b/rtaccess-app/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "backend",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "firebase-admin": "^11.5.0",
+    "cors": "^2.8.5",
+    "@prisma/client": "^5.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/express": "^4.17.0",
+    "@types/cors": "^2.8.1",
+    "ts-node": "^10.0.0",
+    "prisma": "^5.9.0"
+  }
+}

--- a/rtaccess-app/backend/prisma/schema.prisma
+++ b/rtaccess-app/backend/prisma/schema.prisma
@@ -1,0 +1,66 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id    String   @id @default(uuid())
+  name  String
+  email String   @unique
+  avatar String?
+  posts Post[]
+  programs Program[]
+  connectionsFollowed Connection[] @relation("Followed", references: [followedId])
+  connectionsFollower Connection[] @relation("Follower", references: [followerId])
+  messages Message[] @relation("Sender")
+  notifications Notification[]
+}
+
+model Post {
+  id        String   @id @default(uuid())
+  content   String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+}
+
+model Program {
+  id          String   @id @default(uuid())
+  title       String
+  description String
+  user        User?    @relation(fields: [userId], references: [id])
+  userId      String?
+}
+
+model Connection {
+  followerId String
+  followedId String
+  status     String
+  follower   User @relation("Follower", fields: [followerId], references: [id])
+  followed   User @relation("Followed", fields: [followedId], references: [id])
+
+  @@id([followerId, followedId])
+}
+
+model Message {
+  chatId   String
+  senderId String
+  text     String
+  timestamp DateTime @default(now())
+  sender   User @relation("Sender", fields: [senderId], references: [id])
+
+  @@id([chatId, timestamp])
+}
+
+model Notification {
+  id      String   @id @default(uuid())
+  user    User     @relation(fields: [userId], references: [id])
+  userId  String
+  type    String
+  message String
+  read    Boolean @default(false)
+}

--- a/rtaccess-app/backend/src/index.ts
+++ b/rtaccess-app/backend/src/index.ts
@@ -1,0 +1,75 @@
+import express from 'express';
+import cors from 'cors';
+import admin from 'firebase-admin';
+import { verifyFirebaseToken } from './middleware/auth';
+import { PrismaClient } from '@prisma/client';
+
+const app = express();
+const port = process.env.PORT || 3000;
+const prisma = new PrismaClient();
+
+admin.initializeApp();
+
+app.use(cors());
+app.use(express.json());
+
+app.post('/api/login', async (req, res) => {
+  const { token } = req.body;
+  try {
+    const decoded = await admin.auth().verifyIdToken(token);
+    res.json({ uid: decoded.uid });
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+});
+
+app.get('/api/feed', verifyFirebaseToken, async (_req, res) => {
+  const posts = await prisma.post.findMany({ orderBy: { createdAt: 'desc' } });
+  res.json({ items: posts });
+});
+
+app.get('/api/programs', verifyFirebaseToken, async (_req, res) => {
+  const programs = await prisma.program.findMany();
+  res.json({ programs });
+});
+
+app.get('/api/messages', verifyFirebaseToken, async (req, res) => {
+  const userId = (req as any).user.uid as string;
+  const messages = await prisma.message.findMany({ where: { senderId: userId } });
+  res.json({ messages });
+});
+
+app.get('/api/connect', verifyFirebaseToken, async (req, res) => {
+  const q = req.query.q as string | undefined;
+  const users = await prisma.user.findMany({
+    where: q ? { name: { contains: q, mode: 'insensitive' } } : {},
+    take: 10,
+  });
+  res.json({ connections: users });
+});
+
+app.post('/api/connect', verifyFirebaseToken, async (req, res) => {
+  const userId = (req as any).user.uid as string;
+  const { id } = req.body;
+  await prisma.connection.create({
+    data: { followerId: userId, followedId: id, status: 'pending' },
+  });
+  await prisma.notification.create({
+    data: {
+      userId: id,
+      type: 'connection',
+      message: `${userId} wants to connect`,
+    },
+  });
+  res.json({ success: true });
+});
+
+app.get('/api/notifications', verifyFirebaseToken, async (req, res) => {
+  const userId = (req as any).user.uid as string;
+  const notifications = await prisma.notification.findMany({ where: { userId } });
+  res.json({ notifications });
+});
+
+app.listen(port, () => {
+  console.log(`Backend listening on port ${port}`);
+});

--- a/rtaccess-app/backend/src/middleware/auth.ts
+++ b/rtaccess-app/backend/src/middleware/auth.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import admin from 'firebase-admin';
+
+export async function verifyFirebaseToken(req: Request, res: Response, next: NextFunction) {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const token = header.split(' ')[1];
+  try {
+    const decoded = await admin.auth().verifyIdToken(token);
+    (req as any).user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}

--- a/rtaccess-app/backend/tsconfig.json
+++ b/rtaccess-app/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/rtaccess-app/frontend/README.md
+++ b/rtaccess-app/frontend/README.md
@@ -1,0 +1,7 @@
+# Frontend
+
+This React application is built with Vite and TypeScript. Use `npm run dev` to start the development server.
+
+Tailwind CSS is included for styling. The interface features a top navbar with a notification bell slot and a mobile-friendly sidebar containing four tabs (Feed, Programs, Messages, and Connect). Each tab routes to a placeholder page using React Router.
+
+Authentication uses Firebase. Provide your Firebase config in `src/firebase.ts`. After login, the app sends the user's ID token to the backend.

--- a/rtaccess-app/frontend/index.html
+++ b/rtaccess-app/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend</title>
+  </head>
+  <body class="min-h-screen bg-gray-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/rtaccess-app/frontend/package.json
+++ b/rtaccess-app/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "firebase": "^10.7.0",
+    "stream-chat-react": "^11.11.0",
+    "stream-chat": "^8.18.2"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "@types/react-router-dom": "^5.3.3",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/rtaccess-app/frontend/postcss.config.cjs
+++ b/rtaccess-app/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/rtaccess-app/frontend/src/App.tsx
+++ b/rtaccess-app/frontend/src/App.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Sidebar from './components/Sidebar';
+import Navbar from './components/Navbar';
+import Feed from './pages/Feed';
+import Programs from './pages/Programs';
+import Messages from './pages/Messages';
+import Connect from './pages/Connect';
+import Login from './pages/Login';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { auth } from './firebase';
+
+
+export default function App() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return () => unsub();
+  }, []);
+
+  if (loading) return <p>Loading...</p>;
+  if (!user) return <Login />;
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar notificationIcon={<span>🔔</span>} />
+      <div className="flex flex-1">
+        <Sidebar />
+        <main className="flex-1 p-4">
+          <Routes>
+            <Route path="/" element={<Feed />} />
+            <Route path="/programs" element={<Programs />} />
+            <Route path="/messages" element={<Messages />} />
+            <Route path="/connect" element={<Connect />} />
+          </Routes>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/rtaccess-app/frontend/src/components/Navbar.tsx
+++ b/rtaccess-app/frontend/src/components/Navbar.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode, useEffect, useState } from 'react';
+import { auth } from '../firebase';
+
+interface NavbarProps {
+  notificationIcon?: ReactNode;
+}
+
+interface Notification {
+  id: string;
+  read: boolean;
+}
+
+export default function Navbar({ notificationIcon }: NavbarProps) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      const token = await auth.currentUser?.getIdToken();
+      const res = await fetch('http://localhost:3000/api/notifications', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      const unread = (data.notifications || []).filter((n: Notification) => !n.read).length;
+      setCount(unread);
+    };
+    fetchNotifications();
+  }, []);
+
+  return (
+    <header className="flex items-center justify-between bg-white shadow p-4">
+      <h1 className="text-xl font-semibold">RTAccess</h1>
+      <div className="relative text-2xl" aria-label="notifications">
+        {notificationIcon}
+        {count > 0 && (
+          <span className="absolute -top-1 -right-2 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
+            {count}
+          </span>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/rtaccess-app/frontend/src/components/Sidebar.tsx
+++ b/rtaccess-app/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+export default function Sidebar() {
+  const links = [
+    { to: '/', label: 'Feed' },
+    { to: '/programs', label: 'Programs' },
+    { to: '/messages', label: 'Messages' },
+    { to: '/connect', label: 'Connect' },
+  ];
+
+  return (
+    <nav className="bg-gray-100 w-full sm:w-48 p-4">
+      <ul className="flex sm:flex-col gap-4">
+        {links.map((l) => (
+          <li key={l.to}>
+            <NavLink
+              to={l.to}
+              className={({ isActive }) =>
+                `block px-2 py-1 rounded hover:bg-gray-200 ${isActive ? 'font-semibold text-blue-600' : 'text-gray-700'}`
+              }
+            >
+              {l.label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/rtaccess-app/frontend/src/firebase.ts
+++ b/rtaccess-app/frontend/src/firebase.ts
@@ -1,0 +1,19 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getMessaging, onMessage } from 'firebase/messaging';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const messaging = getMessaging(app);
+
+// Listen for foreground messages
+onMessage(messaging, (payload) => {
+  console.log('Message received. ', payload);
+});

--- a/rtaccess-app/frontend/src/index.css
+++ b/rtaccess-app/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/rtaccess-app/frontend/src/main.tsx
+++ b/rtaccess-app/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/rtaccess-app/frontend/src/pages/Connect.tsx
+++ b/rtaccess-app/frontend/src/pages/Connect.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+
+interface UserCard {
+  id: string;
+  name: string;
+  avatar?: string;
+}
+
+export default function Connect() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<UserCard[]>([]);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      const res = await fetch(`http://localhost:3000/api/connect?q=${query}`);
+      const data = await res.json();
+      setResults(data.connections || []);
+    };
+    fetchUsers();
+  }, [query]);
+
+  const handleConnect = async (id: string) => {
+    await fetch('http://localhost:3000/api/connect', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+  };
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">Find People</h2>
+      <input
+        className="border p-2 w-full mb-4"
+        placeholder="Search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        {results.map((u) => (
+          <div key={u.id} className="border p-2 rounded text-center">
+            <img src={u.avatar || 'https://placehold.co/64'} className="mx-auto rounded-full mb-2" />
+            <p className="font-semibold">{u.name}</p>
+            <button
+              className="mt-2 bg-blue-500 text-white px-2 py-1 rounded"
+              onClick={() => handleConnect(u.id)}
+            >
+              Connect
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/rtaccess-app/frontend/src/pages/Feed.tsx
+++ b/rtaccess-app/frontend/src/pages/Feed.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { auth } from '../firebase';
+
+interface Post {
+  id: string;
+  content: string;
+  userId: string;
+  createdAt: string;
+}
+
+export default function Feed() {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      const token = await auth.currentUser?.getIdToken();
+      const res = await fetch('http://localhost:3000/api/feed', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setPosts(data.items || []);
+    };
+    fetchPosts();
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">Feed</h2>
+      <ul className="space-y-2">
+        {posts.map((p) => (
+          <li key={p.id} className="border p-2 rounded">
+            {p.content}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/rtaccess-app/frontend/src/pages/Login.tsx
+++ b/rtaccess-app/frontend/src/pages/Login.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { auth } from '../firebase';
+import { GoogleAuthProvider, signInWithPopup, signInWithEmailAndPassword } from 'firebase/auth';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const provider = new GoogleAuthProvider();
+
+  const notifyBackend = async (token: string) => {
+    await fetch('http://localhost:3000/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+  };
+
+  const handleGoogle = async () => {
+    const result = await signInWithPopup(auth, provider);
+    const token = await result.user.getIdToken();
+    await notifyBackend(token);
+  };
+
+  const handleEmail = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = await signInWithEmailAndPassword(auth, email, password);
+    const token = await result.user.getIdToken();
+    await notifyBackend(token);
+  };
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h2 className="text-xl font-bold mb-4">Login</h2>
+      <form onSubmit={handleEmail} className="space-y-2 mb-4">
+        <input
+          className="border w-full p-2"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border w-full p-2"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit" className="w-full bg-blue-500 text-white p-2 rounded">
+          Login
+        </button>
+      </form>
+      <button onClick={handleGoogle} className="w-full bg-red-500 text-white p-2 rounded">
+        Login with Google
+      </button>
+    </div>
+  );
+}

--- a/rtaccess-app/frontend/src/pages/Messages.tsx
+++ b/rtaccess-app/frontend/src/pages/Messages.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { Chat, ChannelList, Channel, MessageList, MessageInput } from 'stream-chat-react';
+import { StreamChat } from 'stream-chat';
+import 'stream-chat-react/dist/css/v2/index.css';
+
+const apiKey = 'YOUR_STREAM_API_KEY';
+
+export default function Messages() {
+  const [client, setClient] = useState<StreamChat | null>(null);
+  const [channel, setChannel] = useState<any>(null);
+
+  useEffect(() => {
+    const init = async () => {
+      const user = { id: 'demo-user' };
+      const chatClient = StreamChat.getInstance(apiKey);
+      await chatClient.connectUser(user, chatClient.devToken(user.id));
+      setClient(chatClient);
+    };
+    init();
+    return () => { client?.disconnectUser(); };
+  }, []);
+
+  if (!client) return <p>Loading chat...</p>;
+
+  return (
+    <Chat client={client} theme="str-chat__theme-dark">
+      <ChannelList setActiveChannel={setChannel} />
+      {channel && (
+        <Channel channel={channel} >
+          <MessageList />
+          <MessageInput focus />
+        </Channel>
+      )}
+    </Chat>
+  );
+}

--- a/rtaccess-app/frontend/src/pages/Programs.tsx
+++ b/rtaccess-app/frontend/src/pages/Programs.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+interface Program {
+  title: string;
+  description: string;
+}
+
+export default function Programs() {
+  const [input, setInput] = useState('');
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input) return;
+    setLoading(true);
+    try {
+      const res = await fetch('http://localhost:8000/generate-program', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: input }),
+      });
+      const data = await res.json();
+      setPrograms((prev) => [{ title: data.title, description: data.description }, ...prev]);
+      setInput('');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">Generate Programs</h2>
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+        <input
+          className="border p-2 flex-1"
+          placeholder="Population or goal"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" disabled={loading}>
+          {loading ? '...' : 'Generate'}
+        </button>
+      </form>
+      <div className="space-y-4">
+        {programs.map((p, idx) => (
+          <div key={idx} className="border p-4 rounded shadow">
+            <h3 className="font-semibold mb-2">{p.title}</h3>
+            <p>{p.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/rtaccess-app/frontend/src/vite-env.d.ts
+++ b/rtaccess-app/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/rtaccess-app/frontend/tailwind.config.cjs
+++ b/rtaccess-app/frontend/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/rtaccess-app/frontend/tsconfig.json
+++ b/rtaccess-app/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  }
+}

--- a/rtaccess-app/frontend/vite.config.ts
+++ b/rtaccess-app/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up `rtaccess-app` directory structure with three services
- add configuration for frontend (React/Vite/TypeScript)
- add configuration for backend (Express/TypeScript)
- add configuration for ai-service (FastAPI/Python)
- document each service and provide overall README
- add sidebar navigation to React frontend
- add Tailwind CSS setup with new navbar and styled sidebar
- integrate Firebase auth with email/password and Google sign-in
- send ID tokens to the backend and protect API routes with middleware
- add AI service program generation endpoint and CORS
- implement Prisma schema and use Prisma in backend routes
- add notification badge, program generation form, chat UI, and connection grid in frontend

## Testing
- `npm run build` in `/rtaccess-app/backend` *(fails: missing modules)*
- `npm run build` in `/rtaccess-app/frontend` *(fails: vite not found)*
- `git status --short`
- `git log -1 --stat`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685a1a6db6388324a26efc8432cc1730